### PR TITLE
Fixed `updated_at` field of `FollowState` model not being fillable

### DIFF
--- a/src/FollowState.php
+++ b/src/FollowState.php
@@ -25,7 +25,7 @@ class FollowState extends AbstractModel
     /**
      * {@inheritDoc}
      */
-    protected $fillable = ['user_id', 'followed_user_id', 'subscription'];
+    protected $fillable = ['user_id', 'followed_user_id', 'subscription', 'updated_at'];
 
     /**
      * Get the follow user subscription state for the given User.


### PR DESCRIPTION
I realized that this was causing the `updated_at` to never be updated. Making it fillable fixes that issue.