### PR TITLE
fix: Follow button shown to guests, blockers and self

### DIFF
--- a/js/src/forum/addFollowControls.js
+++ b/js/src/forum/addFollowControls.js
@@ -33,11 +33,10 @@ export default function addFollowControls() {
   });
 
   extend(UserCard.prototype, 'view', function (view) {
-    if (!app.forum.attribute('ianm-follow-users.button-on-profile')) {
+    const user = this.attrs.user;
+    if (!app.forum.attribute('ianm-follow-users.button-on-profile') || !app.session.user || app.session.user === user || !user.canBeFollowed()) {
       return;
     }
-
-    const user = this.attrs.user;
 
     /**
      * Opens the SelectFollowLevelModal with the provided user.


### PR DESCRIPTION
Prevent profile card follow button being displayed when:
- Viewing own profile
- Browsing as a guest (closes #18  ) 
- The viewed profile user blocks being followed

