### PR TITLE
fix: switch to `UserSerializer` for `followedUsers` relationship

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -75,7 +75,7 @@ return [
         ->modelPolicy(User::class, Access\UserPolicy::class),
 
     (new Extend\ApiSerializer(CurrentUserSerializer::class))
-        ->hasMany('followedUsers', BasicUserSerializer::class),
+        ->hasMany('followedUsers', UserSerializer::class),
 
     (new Extend\ApiSerializer(BasicUserSerializer::class))
         ->attributes(Api\AddBasicUserAttributes::class),


### PR DESCRIPTION
An issue was brought to my attention, that sometimes user data on the `followedUsers` page is missing / inconsistent. When hard refreshing the page, some of the relations are missing and wrong or no data is displayed in the UserCard. Only after navigating to a user in the list and navigating back, the data was correctly populated. 

Using `BasicUserSerializer` (before):
<img width="874" alt="Screenshot 2024-07-15 at 14 27 26" src="https://github.com/user-attachments/assets/c97e02e8-bede-4fda-8bcb-35b7a0afdcb8">

Using `UserSerializer` (after):
<img width="858" alt="Screenshot 2024-07-15 at 14 26 38" src="https://github.com/user-attachments/assets/147a8fab-d81b-4ef7-88f5-b304ac3ff86e">

This will impact performance, but I think it's unavoidable to switch the Serializer.