### PR TITLE
fix: remove .Button class from follow item in the controls dropdown

### DIFF
--- a/js/src/forum/addFollowControls.js
+++ b/js/src/forum/addFollowControls.js
@@ -51,7 +51,7 @@ export default function addFollowControls() {
 
     items.add(
       'follow',
-      <Button className="Button" icon={icon} onclick={openFollowLevelModal.bind(this, user)}>
+      <Button icon={icon} onclick={openFollowLevelModal.bind(this, user)}>
         {app.translator.trans(`ianm-follow-users.forum.user_controls.${user.followed() ? 'change_button' : 'follow_button'}`)}
       </Button>
     );


### PR DESCRIPTION
I suggest removing the `.Button` class from the follow item in the controls dropdown since all the other items don't have it, and it can cause breaking changes in the UI.

Before
<img width="218" alt="image" src="https://github.com/user-attachments/assets/323becda-bbe1-47ad-854f-2ba6c28d2c40" />

After
<img width="230" alt="image" src="https://github.com/user-attachments/assets/416426e9-588d-4e00-8c55-b8a0caee3dce" />
