### PR TITLE
tests: add coverage for filters, canBeFollowed, and stats-on-profile setting

### DIFF
--- a/tests/integration/api/FollowUsersDiscussionFilterTest.php
+++ b/tests/integration/api/FollowUsersDiscussionFilterTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of ianm/follow-users
+ *
+ *  Copyright (c) Ian Morland.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace IanM\FollowUsers\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class FollowUsersDiscussionFilterTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('ianm-follow-users');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'user3', 'email' => 'user3@machine.local', 'is_email_confirmed' => true],
+            ],
+            'discussions' => [
+                // Started by followed user (user 3)
+                ['id' => 1, 'title' => 'Discussion by followed user', 'user_id' => 3, 'participant_count' => 1, 'created_at' => '2024-01-01 00:00:00'],
+                // Started by the actor themselves (user 2)
+                ['id' => 2, 'title' => 'Discussion by actor', 'user_id' => 2, 'participant_count' => 1, 'created_at' => '2024-01-01 00:00:00'],
+                // Started by admin (user 1), not followed
+                ['id' => 3, 'title' => 'Discussion by admin', 'user_id' => 1, 'participant_count' => 1, 'created_at' => '2024-01-01 00:00:00'],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'user_id' => 3, 'type' => 'comment', 'content' => '<t><p>Post 1</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => '2024-01-01 00:00:00'],
+                ['id' => 2, 'discussion_id' => 2, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>Post 2</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => '2024-01-01 00:00:00'],
+                ['id' => 3, 'discussion_id' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Post 3</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => '2024-01-01 00:00:00'],
+            ],
+            'user_followers' => [
+                // user 2 follows user 3
+                ['id' => 1, 'user_id' => 2, 'followed_user_id' => 3, 'subscription' => 'follow', 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00'],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_returns_only_discussions_by_followed_users(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+                ->withQueryParams(['filter' => ['following-users' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $ids = array_column($json['data'], 'id');
+
+        $this->assertContains('1', $ids);
+        $this->assertNotContains('2', $ids);
+        $this->assertNotContains('3', $ids);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_returns_empty_when_actor_follows_nobody(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 3])
+                ->withQueryParams(['filter' => ['following-users' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEmpty($json['data']);
+    }
+
+    /**
+     * Guest actors have no follow relationships so the filter is a no-op —
+     * all visible discussions are returned unchanged.
+     *
+     * @test
+     */
+    public function filter_is_a_noop_for_guests(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+                ->withQueryParams(['filter' => ['following-users' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertCount(3, $json['data']);
+    }
+}

--- a/tests/integration/api/FollowedUsersFilterGambitTest.php
+++ b/tests/integration/api/FollowedUsersFilterGambitTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of ianm/follow-users
+ *
+ *  Copyright (c) Ian Morland.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace IanM\FollowUsers\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class FollowedUsersFilterGambitTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('ianm-follow-users');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'user3', 'email' => 'user3@machine.local', 'is_email_confirmed' => true],
+                ['id' => 4, 'username' => 'user4', 'email' => 'user4@machine.local', 'is_email_confirmed' => true],
+            ],
+            'user_followers' => [
+                // user 2 follows user 3 only
+                ['id' => 1, 'user_id' => 2, 'followed_user_id' => 3, 'subscription' => 'follow', 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00'],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_returns_only_followed_users(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users', ['authenticatedAs' => 2])
+                ->withQueryParams(['filter' => ['followeduser' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $ids = array_column($json['data'], 'id');
+
+        $this->assertContains('3', $ids);
+        $this->assertNotContains('1', $ids);
+        $this->assertNotContains('2', $ids);
+        $this->assertNotContains('4', $ids);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_returns_empty_when_actor_follows_nobody(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users', ['authenticatedAs' => 3])
+                ->withQueryParams(['filter' => ['followeduser' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEmpty($json['data']);
+    }
+}

--- a/tests/integration/api/UserAttributesTest.php
+++ b/tests/integration/api/UserAttributesTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of ianm/follow-users
+ *
+ *  Copyright (c) Ian Morland.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace IanM\FollowUsers\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class UserAttributesTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('ianm-follow-users');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'user3', 'email' => 'user3@machine.local', 'is_email_confirmed' => true],
+                ['id' => 4, 'username' => 'blocker', 'email' => 'blocker@machine.local', 'is_email_confirmed' => true, 'preferences' => json_encode(['blocksFollow' => true])],
+            ],
+            'user_followers' => [
+                // user 2 follows user 3
+                ['id' => 1, 'user_id' => 2, 'followed_user_id' => 3, 'subscription' => 'follow', 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00'],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function can_be_followed_is_true_for_regular_user(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/3', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertTrue($json['data']['attributes']['canBeFollowed']);
+    }
+
+    /**
+     * @test
+     */
+    public function can_be_followed_is_false_for_self(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/2', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertFalse($json['data']['attributes']['canBeFollowed']);
+    }
+
+    /**
+     * @test
+     */
+    public function can_be_followed_is_false_when_user_blocks_following(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/4', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertFalse($json['data']['attributes']['canBeFollowed']);
+    }
+
+    /**
+     * @test
+     */
+    public function followed_attribute_reflects_subscription_type(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/3', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals('follow', $json['data']['attributes']['followed']);
+    }
+
+    /**
+     * @test
+     */
+    public function followed_attribute_is_null_for_non_followed_user(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/4', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertNull($json['data']['attributes']['followed']);
+    }
+
+    /**
+     * @test
+     */
+    public function follower_and_following_counts_are_present_when_stats_enabled(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/3', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $attributes = $json['data']['attributes'];
+
+        $this->assertArrayHasKey('followerCount', $attributes);
+        $this->assertArrayHasKey('followingCount', $attributes);
+        $this->assertEquals(1, $attributes['followerCount']);
+        $this->assertEquals(0, $attributes['followingCount']);
+    }
+
+    /**
+     * @test
+     */
+    public function follower_and_following_counts_are_absent_when_stats_disabled(): void
+    {
+        $this->setting('ianm-follow-users.stats-on-profile', false);
+
+        $response = $this->send(
+            $this->request('GET', '/api/users/3', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $attributes = $json['data']['attributes'];
+
+        $this->assertArrayNotHasKey('followerCount', $attributes);
+        $this->assertArrayNotHasKey('followingCount', $attributes);
+    }
+}


### PR DESCRIPTION
Adds integration tests for three previously untested areas:

- **FollowedUsersFilterGambitTest** — `filter[followeduser]` on the user list
- **FollowUsersDiscussionFilterTest** — `filter[following-users]` on discussions, including the guest no-op behaviour
- **UserAttributesTest** — `canBeFollowed` (self, blocker, regular user), `followed` subscription value, and follower/following counts hidden when `stats-on-profile` is disabled