### PR TITLE
[2.x] fix: eliminate N+1 queries when listing users

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -12,13 +12,16 @@
 
 namespace IanM\FollowUsers;
 
+use Flarum\Api\Context;
 use Flarum\Api\Endpoint;
 use Flarum\Api\Resource;
+use Flarum\Database\Eloquent\Collection;
 use Flarum\Discussion\Event as DiscussionEvent;
 use Flarum\Extend;
 use Flarum\Gdpr\Extend\UserData;
 use Flarum\User\Search\UserSearcher;
 use Flarum\User\User;
+use IanM\FollowUsers\FollowState;
 
 return [
     (new Extend\Frontend('forum'))
@@ -60,7 +63,43 @@ return [
     (new Extend\ApiResource(Resource\UserResource::class))
         ->fields(Api\UserResourceFields::class)
         ->endpoint(Endpoint\Index::class, function (Endpoint\Index $endpoint) {
-            return $endpoint->addDefaultInclude(['followedUsers']);
+            return $endpoint
+                ->addDefaultInclude(['followedUsers'])
+                ->beforeSerialization(function (Context $context, array $results) {
+                    $models = Collection::make($results['models']);
+
+                    if ($models->isEmpty()) {
+                        return;
+                    }
+
+                    // Preload groups for every user in one batch query instead
+                    // of one query per user during serialization.
+                    $models->loadMissing('groups');
+
+                    // Preload follower/following counts for every user in a
+                    // single correlated-subquery SELECT, then seed the static
+                    // cache so the field getters never need to COUNT individually.
+                    $models->loadCount(['followedUsers', 'followedBy']);
+                    foreach ($models as $user) {
+                        FollowState::seedCountCache(
+                            (int) $user->id,
+                            (int) ($user->followed_by_count ?? 0),
+                            (int) ($user->followed_users_count ?? 0),
+                        );
+                    }
+
+                    // Preload the actor's follow state for every listed user in
+                    // a single SELECT … WHERE followed_user_id IN (…) query,
+                    // then seed the static cache so FollowState::for() never
+                    // needs to query individually.
+                    $actor = $context->getActor();
+                    if (!$actor->isGuest()) {
+                        FollowState::seedActorFollowStates(
+                            (int) $actor->id,
+                            $models->pluck('id')->map(fn ($id) => (int) $id)->all(),
+                        );
+                    }
+                });
         })
         ->endpoint(Endpoint\Show::class, function (Endpoint\Show $endpoint) {
             return $endpoint->addDefaultInclude(['followedUsers', 'followedBy']);

--- a/extend.php
+++ b/extend.php
@@ -21,7 +21,6 @@ use Flarum\Extend;
 use Flarum\Gdpr\Extend\UserData;
 use Flarum\User\Search\UserSearcher;
 use Flarum\User\User;
-use IanM\FollowUsers\FollowState;
 
 return [
     (new Extend\Frontend('forum'))

--- a/extend.php
+++ b/extend.php
@@ -65,9 +65,9 @@ return [
             return $endpoint
                 ->addDefaultInclude(['followedUsers'])
                 ->beforeSerialization(function (Context $context, array $results) {
-                    $models = Collection::make($results['models']);
+                    $models = $results['models'];
 
-                    if ($models->isEmpty()) {
+                    if (!($models instanceof Collection) || $models->isEmpty()) {
                         return;
                     }
 
@@ -81,9 +81,9 @@ return [
                     $models->loadCount(['followedUsers', 'followedBy']);
                     foreach ($models as $user) {
                         FollowState::seedCountCache(
-                            (int) $user->id,
-                            (int) ($user->followed_by_count ?? 0),
-                            (int) ($user->followed_users_count ?? 0),
+                            (int) $user->getKey(),
+                            (int) ($user->getAttribute('followed_by_count') ?? 0),
+                            (int) ($user->getAttribute('followed_users_count') ?? 0),
                         );
                     }
 
@@ -95,7 +95,7 @@ return [
                     if (!$actor->isGuest()) {
                         FollowState::seedActorFollowStates(
                             (int) $actor->id,
-                            $models->pluck('id')->map(fn ($id) => (int) $id)->all(),
+                            $models->map(fn ($u) => (int) $u->getKey())->all(),
                         );
                     }
                 });

--- a/src/FollowState.php
+++ b/src/FollowState.php
@@ -35,41 +35,110 @@ class FollowState extends AbstractModel
     ];
 
     /**
-     * Get the follow user subscription state for the given User.
+     * Request-scoped cache of actor→user follow subscription strings.
+     * Keyed as "{actor_id}:{user_id}" → subscription|null.
      *
-     * @param User $actor
-     * @param User $user
+     * @var array<string, string|null>
+     */
+    private static array $followStateCache = [];
+
+    /**
+     * Request-scoped cache of follower counts (users following a given user).
+     * Keyed as user_id → count.
      *
-     * @return null|string
+     * @var array<int, int>
+     */
+    private static array $followerCountCache = [];
+
+    /**
+     * Request-scoped cache of following counts (users a given user follows).
+     * Keyed as user_id → count.
+     *
+     * @var array<int, int>
+     */
+    private static array $followingCountCache = [];
+
+    /**
+     * Pre-seed the static count caches from Eloquent loadCount() results so
+     * that subsequent per-user getFollowerCount/getFollowingCount calls are
+     * served from memory instead of issuing individual COUNT queries.
+     */
+    public static function seedCountCache(int $userId, int $followerCount, int $followingCount): void
+    {
+        self::$followerCountCache[$userId]  = $followerCount;
+        self::$followingCountCache[$userId] = $followingCount;
+    }
+
+    /**
+     * Batch-load the actor's follow state for every user in $userIds using a
+     * single SELECT, then seed the follow-state cache so that FollowState::for()
+     * can serve results from memory without issuing per-user queries.
+     *
+     * All entries are written unconditionally so that stale data from a
+     * previous request (e.g. between integration test cases) is overwritten.
+     *
+     * @param int   $actorId
+     * @param int[] $userIds
+     */
+    public static function seedActorFollowStates(int $actorId, array $userIds): void
+    {
+        if (empty($userIds)) {
+            return;
+        }
+
+        // Pre-mark every user as "not followed"; overwrite any stale entry.
+        foreach ($userIds as $userId) {
+            self::$followStateCache[$actorId.':'.$userId] = null;
+        }
+
+        // One query to fetch all real follow states and overwrite the nulls.
+        self::where('user_id', $actorId)
+            ->whereIn('followed_user_id', $userIds)
+            ->each(function (self $state) use ($actorId): void {
+                self::$followStateCache[$actorId.':'.(int) $state->followed_user_id] = $state->subscription;
+            });
+    }
+
+    /**
+     * Get the follow subscription state for the given actor→user pair.
+     * Returns the cached value if already loaded; otherwise queries the DB
+     * and caches the result for the remainder of the request.
      */
     public static function for(User $actor, User $user): ?string
     {
-        $sub = self::where('user_id', $actor->id)->where('followed_user_id', $user->id)->first();
+        $key = $actor->id.':'.$user->id;
 
-        return $sub ? $sub->subscription : null;
+        if (!array_key_exists($key, self::$followStateCache)) {
+            $sub = self::where('user_id', $actor->id)->where('followed_user_id', $user->id)->first();
+            self::$followStateCache[$key] = $sub?->subscription;
+        }
+
+        return self::$followStateCache[$key];
     }
 
     /**
      * Get the number of users the given user is following.
-     *
-     * @param User $user
-     *
-     * @return int
+     * Returns the cached value if already loaded; otherwise queries the DB.
      */
     public static function getFollowingCount(User $user): int
     {
-        return self::where('user_id', $user->id)->count();
+        if (!isset(self::$followingCountCache[(int) $user->id])) {
+            self::$followingCountCache[(int) $user->id] = self::where('user_id', $user->id)->count();
+        }
+
+        return self::$followingCountCache[(int) $user->id];
     }
 
     /**
      * Get the number of users following the given user.
-     *
-     * @param User $user
-     *
-     * @return int
+     * Returns the cached value if already loaded; otherwise queries the DB.
      */
     public static function getFollowerCount(User $user): int
     {
-        return self::where('followed_user_id', $user->id)->count();
+        if (!isset(self::$followerCountCache[(int) $user->id])) {
+            self::$followerCountCache[(int) $user->id] = self::where('followed_user_id', $user->id)->count();
+        }
+
+        return self::$followerCountCache[(int) $user->id];
     }
 }

--- a/src/FollowState.php
+++ b/src/FollowState.php
@@ -65,7 +65,7 @@ class FollowState extends AbstractModel
      */
     public static function seedCountCache(int $userId, int $followerCount, int $followingCount): void
     {
-        self::$followerCountCache[$userId]  = $followerCount;
+        self::$followerCountCache[$userId] = $followerCount;
         self::$followingCountCache[$userId] = $followingCount;
     }
 

--- a/tests/integration/api/FollowUserTest.php
+++ b/tests/integration/api/FollowUserTest.php
@@ -16,8 +16,10 @@ use Flarum\Notification\Notification;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Test;
 
+#[RunTestsInSeparateProcesses]
 class FollowUserTest extends TestCase
 {
     use RetrievesAuthorizedUsers;

--- a/tests/integration/api/FollowUsersDiscussionFilterTest.php
+++ b/tests/integration/api/FollowUsersDiscussionFilterTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of ianm/follow-users
+ *
+ *  Copyright (c) Ian Morland.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace IanM\FollowUsers\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\Test;
+
+#[RunTestsInSeparateProcesses]
+class FollowUsersDiscussionFilterTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('ianm-follow-users');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'user3', 'email' => 'user3@machine.local', 'is_email_confirmed' => true],
+            ],
+            'discussions' => [
+                // Started by followed user (user 3)
+                ['id' => 1, 'title' => 'Discussion by followed user', 'slug' => 'discussion-by-followed-user', 'user_id' => 3, 'participant_count' => 1, 'created_at' => '2024-01-01 00:00:00'],
+                // Started by the actor themselves (user 2)
+                ['id' => 2, 'title' => 'Discussion by actor', 'slug' => 'discussion-by-actor', 'user_id' => 2, 'participant_count' => 1, 'created_at' => '2024-01-01 00:00:00'],
+                // Started by admin (user 1), not followed
+                ['id' => 3, 'title' => 'Discussion by admin', 'slug' => 'discussion-by-admin', 'user_id' => 1, 'participant_count' => 1, 'created_at' => '2024-01-01 00:00:00'],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'user_id' => 3, 'type' => 'comment', 'content' => '<t><p>Post 1</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => '2024-01-01 00:00:00'],
+                ['id' => 2, 'discussion_id' => 2, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>Post 2</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => '2024-01-01 00:00:00'],
+                ['id' => 3, 'discussion_id' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Post 3</p></t>', 'is_private' => 0, 'number' => 1, 'created_at' => '2024-01-01 00:00:00'],
+            ],
+            'user_followers' => [
+                // user 2 follows user 3
+                ['id' => 1, 'user_id' => 2, 'followed_user_id' => 3, 'subscription' => 'follow', 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00'],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function filter_returns_only_discussions_by_followed_users(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+                ->withQueryParams(['filter' => ['following-users' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $ids = array_column($json['data'], 'id');
+
+        $this->assertContains('1', $ids);
+        $this->assertNotContains('2', $ids);
+        $this->assertNotContains('3', $ids);
+    }
+
+    #[Test]
+    public function filter_returns_empty_when_actor_follows_nobody(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 3])
+                ->withQueryParams(['filter' => ['following-users' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEmpty($json['data']);
+    }
+
+    /**
+     * Guest actors have no follow relationships so the filter is a no-op —
+     * all visible discussions are returned unchanged.
+     */
+    #[Test]
+    public function filter_is_a_noop_for_guests(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions')
+                ->withQueryParams(['filter' => ['following-users' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertCount(3, $json['data']);
+    }
+}

--- a/tests/integration/api/FollowedByTest.php
+++ b/tests/integration/api/FollowedByTest.php
@@ -15,8 +15,10 @@ namespace IanM\FollowUsers\Tests\integration\api;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Test;
 
+#[RunTestsInSeparateProcesses]
 class FollowedByTest extends TestCase
 {
     use RetrievesAuthorizedUsers;

--- a/tests/integration/api/FollowedUsersFilterGambitTest.php
+++ b/tests/integration/api/FollowedUsersFilterGambitTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of ianm/follow-users
+ *
+ *  Copyright (c) Ian Morland.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace IanM\FollowUsers\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\Test;
+
+#[RunTestsInSeparateProcesses]
+class FollowedUsersFilterGambitTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('ianm-follow-users');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'user3', 'email' => 'user3@machine.local', 'is_email_confirmed' => true],
+                ['id' => 4, 'username' => 'user4', 'email' => 'user4@machine.local', 'is_email_confirmed' => true],
+            ],
+            'user_followers' => [
+                // user 2 follows user 3 only
+                ['id' => 1, 'user_id' => 2, 'followed_user_id' => 3, 'subscription' => 'follow', 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00'],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function filter_returns_only_followed_users(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users', ['authenticatedAs' => 2])
+                ->withQueryParams(['filter' => ['followeduser' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $ids = array_column($json['data'], 'id');
+
+        $this->assertContains('3', $ids);
+        $this->assertNotContains('1', $ids);
+        $this->assertNotContains('2', $ids);
+        $this->assertNotContains('4', $ids);
+    }
+
+    #[Test]
+    public function filter_returns_empty_when_actor_follows_nobody(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users', ['authenticatedAs' => 3])
+                ->withQueryParams(['filter' => ['followeduser' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEmpty($json['data']);
+    }
+}

--- a/tests/integration/api/FollowedUsersFilterTest.php
+++ b/tests/integration/api/FollowedUsersFilterTest.php
@@ -15,6 +15,7 @@ namespace IanM\FollowUsers\Tests\integration\api;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
@@ -26,6 +27,7 @@ use PHPUnit\Framework\Attributes\Test;
  *
  * The column references must be qualified as `users.id`.
  */
+#[RunTestsInSeparateProcesses]
 class FollowedUsersFilterTest extends TestCase
 {
     use RetrievesAuthorizedUsers;

--- a/tests/integration/api/FollowingUserTest.php
+++ b/tests/integration/api/FollowingUserTest.php
@@ -17,8 +17,10 @@ use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Test;
 
+#[RunTestsInSeparateProcesses]
 class FollowingUserTest extends TestCase
 {
     use RetrievesAuthorizedUsers;

--- a/tests/integration/api/ForumRelationTest.php
+++ b/tests/integration/api/ForumRelationTest.php
@@ -15,8 +15,10 @@ namespace IanM\FollowUsers\Tests\integration\api;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Test;
 
+#[RunTestsInSeparateProcesses]
 class ForumRelationTest extends TestCase
 {
     use RetrievesAuthorizedUsers;

--- a/tests/integration/api/ListUsersQueryCountTest.php
+++ b/tests/integration/api/ListUsersQueryCountTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of ianm/follow-users
+ *
+ *  Copyright (c) Ian Morland.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace IanM\FollowUsers\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Illuminate\Database\Connection;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards against N+1 queries in UserResourceFields when listing users.
+ *
+ * Without the fix, three queries are issued PER serialized user:
+ *   - FollowState::for()               → SELECT from user_followers (followed state)
+ *   - FollowState::getFollowerCount()  → COUNT from user_followers
+ *   - FollowState::getFollowingCount() → COUNT from user_followers
+ *
+ * The two tests seed different numbers of users but assert the SAME query ceiling,
+ * proving the count is constant (O(1)) regardless of list size.
+ *
+ * --- Query budget breakdown (ceiling = 15) ---
+ *
+ *  5  fixed request overhead: actor lookup, last_seen update, actor groups,
+ *     list SELECT, pagination COUNT
+ *  1  groups batch     loadMissing('groups') for all listed users
+ *  1  counts batch     loadCount(['followedUsers','followedBy']) — single correlated-subquery SELECT
+ *  1  follow-state batch  seedActorFollowStates — one SELECT … WHERE … IN (…)
+ *  2  notification counts  unreadNotificationCount + newNotificationCount for the actor
+ *     (visible-to-self fields in core UserResource; not present in 1.x BasicUserSerializer)
+ *  1  followedUsers include batch
+ * ---
+ * 11  total (access_tokens queries from the 2.x test framework are excluded as infrastructure noise)
+ */
+#[RunTestsInSeparateProcesses]
+class ListUsersQueryCountTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('ianm-follow-users');
+    }
+
+    protected function seedUsers(array $users, array $followers = []): void
+    {
+        $this->prepareDatabase([
+            User::class      => $users,
+            'user_followers' => $followers,
+        ]);
+    }
+
+    protected function queryCountForUserList(): array
+    {
+        /** @var Connection $db */
+        $db = $this->database();
+        $db->enableQueryLog();
+
+        $response = $this->send(
+            $this->request('GET', '/api/users', ['authenticatedAs' => 1])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $log = $db->getQueryLog();
+        $db->flushQueryLog();
+
+        // Exclude access_tokens queries — they are test-framework infrastructure
+        // (Flarum 2.x creates real DB tokens; 1.x used session variables with 0 DB
+        // overhead). Filtering them keeps the ceiling comparable to the 1.x baseline.
+        return array_values(array_filter($log, fn ($q) => !str_contains($q['query'], 'access_tokens')));
+    }
+
+    #[Test]
+    public function list_users_with_few_users(): void
+    {
+        $this->seedUsers(
+            [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'user3', 'email' => 'user3@machine.local', 'is_email_confirmed' => true],
+                ['id' => 4, 'username' => 'user4', 'email' => 'user4@machine.local', 'is_email_confirmed' => true],
+            ],
+            [
+                ['id' => 1, 'user_id' => 2, 'followed_user_id' => 3, 'subscription' => 'follow', 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00'],
+                ['id' => 2, 'user_id' => 3, 'followed_user_id' => 4, 'subscription' => 'follow', 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00'],
+            ]
+        );
+
+        $log = $this->queryCountForUserList();
+
+        $this->assertLessThanOrEqual(11, count($log), $this->formatQueryLog($log));
+    }
+
+    #[Test]
+    public function list_users_with_many_users(): void
+    {
+        $users = [$this->normalUser()];
+        $followers = [];
+
+        for ($i = 3; $i <= 12; $i++) {
+            $users[] = [
+                'id'                 => $i,
+                'username'           => "user{$i}",
+                'email'              => "user{$i}@machine.local",
+                'is_email_confirmed' => true,
+            ];
+            $followers[] = [
+                'id'               => $i - 2,
+                'user_id'          => $i - 1,
+                'followed_user_id' => $i,
+                'subscription'     => 'follow',
+                'created_at'       => '2024-01-01 00:00:00',
+                'updated_at'       => '2024-01-01 00:00:00',
+            ];
+        }
+
+        $this->seedUsers($users, $followers);
+
+        $log = $this->queryCountForUserList();
+
+        $this->assertLessThanOrEqual(11, count($log), $this->formatQueryLog($log));
+    }
+
+    private function formatQueryLog(array $log): string
+    {
+        return sprintf(
+            "%d queries executed:\n%s",
+            count($log),
+            implode("\n", array_map(fn ($q) => '  '.$q['query'], $log))
+        );
+    }
+}

--- a/tests/integration/api/UserAttributesTest.php
+++ b/tests/integration/api/UserAttributesTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of ianm/follow-users
+ *
+ *  Copyright (c) Ian Morland.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace IanM\FollowUsers\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\Test;
+
+#[RunTestsInSeparateProcesses]
+class UserAttributesTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('ianm-follow-users');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'user3', 'email' => 'user3@machine.local', 'is_email_confirmed' => true],
+                ['id' => 4, 'username' => 'blocker', 'email' => 'blocker@machine.local', 'is_email_confirmed' => true, 'preferences' => json_encode(['blocksFollow' => true])],
+            ],
+            'user_followers' => [
+                // user 2 follows user 3
+                ['id' => 1, 'user_id' => 2, 'followed_user_id' => 3, 'subscription' => 'follow', 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00'],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function can_be_followed_is_true_for_regular_user(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/3', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertTrue($json['data']['attributes']['canBeFollowed']);
+    }
+
+    #[Test]
+    public function can_be_followed_is_false_for_self(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/2', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertFalse($json['data']['attributes']['canBeFollowed']);
+    }
+
+    #[Test]
+    public function can_be_followed_is_false_when_user_blocks_following(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/4', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertFalse($json['data']['attributes']['canBeFollowed']);
+    }
+
+    #[Test]
+    public function followed_attribute_reflects_subscription_type(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/3', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals('follow', $json['data']['attributes']['followed']);
+    }
+
+    #[Test]
+    public function followed_attribute_is_null_for_non_followed_user(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/4', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertNull($json['data']['attributes']['followed']);
+    }
+
+    #[Test]
+    public function follower_and_following_counts_are_present_when_stats_enabled(): void
+    {
+        $this->setting('ianm-follow-users.stats-on-profile', true);
+
+        $response = $this->send(
+            $this->request('GET', '/api/users/3', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $attributes = $json['data']['attributes'];
+
+        $this->assertArrayHasKey('followerCount', $attributes);
+        $this->assertArrayHasKey('followingCount', $attributes);
+        $this->assertEquals(1, $attributes['followerCount']);
+        $this->assertEquals(0, $attributes['followingCount']);
+    }
+
+    #[Test]
+    public function follower_and_following_counts_are_absent_when_stats_disabled(): void
+    {
+        $this->setting('ianm-follow-users.stats-on-profile', false);
+
+        $response = $this->send(
+            $this->request('GET', '/api/users/3', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $attributes = $json['data']['attributes'];
+
+        $this->assertArrayNotHasKey('followerCount', $attributes);
+        $this->assertArrayNotHasKey('followingCount', $attributes);
+    }
+}

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,25 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="true"
-    stopOnFailure="false"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">../src/</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Flarum Integration Tests">
-            <directory suffix="Test.php">./integration</directory>
-             <exclude>./integration/tmp</exclude>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" colors="true" stopOnFailure="false">
+  <testsuites>
+    <testsuite name="Flarum Integration Tests">
+      <directory suffix="Test.php">./integration</directory>
+      <exclude>./integration/tmp</exclude>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -1,27 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">../src/</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Flarum Unit Tests">
-            <directory suffix="Test.php">./unit</directory>
-        </testsuite>
-    </testsuites>
-    <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
-    </listeners>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" colors="true" stopOnFailure="false">
+  <testsuites>
+    <testsuite name="Flarum Unit Tests">
+      <directory suffix="Test.php">./unit</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../src/</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
Batch-loads groups, follower/following counts, and actor follow states in a `beforeSerialization` hook on the `UserResource` index endpoint, so the number of queries is constant regardless of how many users are in the list.

Adds request-scoped static caches to `FollowState` (`seedCountCache`, `seedActorFollowStates`) so serializer field getters never fall back to per-user queries once the batch has run.

Also migrates integration tests to PHPUnit 11 (attribute syntax, `#[RunTestsInSeparateProcesses]`, updated XML schema), and ports `FollowUsersDiscussionFilterTest`, `FollowedUsersFilterGambitTest`, `UserAttributesTest`, and `ListUsersQueryCountTest` (N+1 regression guard) from the 1.x branch.