### PR TITLE
[2.x] fix: correct placeholder keys in notification email subjects

### DIFF
--- a/src/Notifications/NewDiscussionBlueprint.php
+++ b/src/Notifications/NewDiscussionBlueprint.php
@@ -62,7 +62,7 @@ class NewDiscussionBlueprint implements BlueprintInterface, MailableInterface, A
     public function getEmailSubject(\Flarum\Locale\TranslatorInterface $translator): string
     {
         return $translator->trans('ianm-follow-users.email.new_discussion_by_user.subject', [
-            '{title}' => $this->discussion->title,
+            '{user_display_name}' => $this->discussion->user->display_name,
         ]);
     }
 

--- a/src/Notifications/NewFollowerBlueprint.php
+++ b/src/Notifications/NewFollowerBlueprint.php
@@ -61,7 +61,7 @@ class NewFollowerBlueprint implements BlueprintInterface, MailableInterface, Ale
     public function getEmailSubject(\Flarum\Locale\TranslatorInterface $translator): string
     {
         return $translator->trans('ianm-follow-users.email.new_follower.subject', [
-            '{username}' => $this->actor->username,
+            '{follower_display_name}' => $this->actor->display_name,
         ]);
     }
 

--- a/src/Notifications/NewPostByUserBlueprint.php
+++ b/src/Notifications/NewPostByUserBlueprint.php
@@ -62,7 +62,8 @@ class NewPostByUserBlueprint implements BlueprintInterface, MailableInterface, A
     public function getEmailSubject(\Flarum\Locale\TranslatorInterface $translator): string
     {
         return $translator->trans('ianm-follow-users.email.new_post.subject', [
-            '{title}' => $this->post->discussion->title,
+            '{user_display_name}'  => $this->post->user->display_name,
+            '{discussion_title}'   => $this->post->discussion->title,
         ]);
     }
 


### PR DESCRIPTION
All three `getEmailSubject()` implementations were passing placeholder keys that don't exist in the translation strings, causing literal `{placeholder}` text to appear in email subject lines.

| Blueprint | Was passing | Translation expects |
|---|---|---|
| `NewDiscussionBlueprint` | `{title}` | `{user_display_name}` |
| `NewFollowerBlueprint` | `{username}` | `{follower_display_name}` |
| `NewPostByUserBlueprint` | `{title}` | `{user_display_name}` + `{discussion_title}` |

Email bodies (Blade templates) were already correct — only the subject lines were affected.

Fixes the reported issue where users receive emails with raw placeholder strings in the subject.