### PR TITLE
[2.x] fix: batch follow-state loading for users included from any endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "require-dev": {
         "flarum/phpstan": "^2.0.0",
-        "flarum/testing": "^2.0.0",
+        "flarum/testing": "2.x-dev",
         "flarum/approval": "^2.0.0",
         "fof/user-directory": "^2.0.0",
         "flarum/gdpr": "^2.0.0"

--- a/extend.php
+++ b/extend.php
@@ -55,6 +55,14 @@ return [
     (new Extend\User())
         ->registerPreference('blocksFollow', 'boolval', false),
 
+    // FollowState memoises per-request; a persistent runtime reuses the process,
+    // so the caches have to be cleared explicitly for each request.
+    (new Extend\Middleware('api'))
+        ->add(Middleware\FlushFollowStateCache::class),
+
+    (new Extend\Middleware('forum'))
+        ->add(Middleware\FlushFollowStateCache::class),
+
     (new Extend\Policy())
         ->modelPolicy(User::class, Access\UserPolicy::class),
 

--- a/src/Api/UserResourceFields.php
+++ b/src/Api/UserResourceFields.php
@@ -34,16 +34,42 @@ class UserResourceFields
     {
         return [
             // Basic user attributes (available on BasicUserSerializer)
+            //
+            // These getters return a closure rather than a value. The serializer
+            // treats a returned Closure as deferred work: it is queued and only
+            // invoked once every model in the document has been walked (see
+            // Serializer::whenResolved / resolveDeferred). That gives us a point
+            // where the full set of users being serialized is known, so the
+            // first closure to resolve can load follow data for all of them in
+            // one query instead of one query per user.
+            //
+            // This is what makes the batching work on endpoints other than
+            // /api/users — /api/discussions, /api/posts, /api/notifications and
+            // any third-party resource that includes users — none of which can
+            // be reached by the beforeSerialization hook in extend.php, since
+            // that is bound to a single (resource, endpoint) pair.
             Schema\Str::make('followed')
-                ->get(fn (User $user, Context $context) => FollowState::for($context->getActor(), $user)),
+                ->get(function (User $user, Context $context) {
+                    FollowState::willSerialize($context->getActor(), $user);
+
+                    return fn () => FollowState::for($context->getActor(), $user);
+                }),
 
             Schema\Integer::make('followerCount')
                 ->visible(fn (User $user, Context $context) => (bool) $this->settings->get('ianm-follow-users.stats-on-profile'))
-                ->get(fn (User $user, Context $context) => FollowState::getFollowerCount($user)),
+                ->get(function (User $user, Context $context) {
+                    FollowState::willSerialize($context->getActor(), $user);
+
+                    return fn () => FollowState::getFollowerCount($user);
+                }),
 
             Schema\Integer::make('followingCount')
                 ->visible(fn (User $user, Context $context) => (bool) $this->settings->get('ianm-follow-users.stats-on-profile'))
-                ->get(fn (User $user, Context $context) => FollowState::getFollowingCount($user)),
+                ->get(function (User $user, Context $context) {
+                    FollowState::willSerialize($context->getActor(), $user);
+
+                    return fn () => FollowState::getFollowingCount($user);
+                }),
 
             // User-level attributes (available on UserSerializer)
             Schema\Boolean::make('canBeFollowed')

--- a/src/FollowState.php
+++ b/src/FollowState.php
@@ -59,6 +59,20 @@ class FollowState extends AbstractModel
     private static array $followingCountCache = [];
 
     /**
+     * User IDs seen during serialization whose follow data has not been loaded
+     * yet. Collected while the serializer walks the document; drained by a
+     * single batch query the first time a deferred field getter resolves.
+     *
+     * @var array<int, true>
+     */
+    private static array $pendingUserIds = [];
+
+    /**
+     * The actor the pending IDs are to be resolved against.
+     */
+    private static ?int $pendingActorId = null;
+
+    /**
      * Pre-seed the static count caches from Eloquent loadCount() results so
      * that subsequent per-user getFollowerCount/getFollowingCount calls are
      * served from memory instead of issuing individual COUNT queries.
@@ -100,6 +114,119 @@ class FollowState extends AbstractModel
     }
 
     /**
+     * Note that a user is going to be serialized, so that their follow data can
+     * be loaded alongside every other user in the same document.
+     *
+     * Called while the serializer walks the document, before any deferred field
+     * getter has resolved. Registering costs nothing; the query happens once,
+     * when the first getter actually needs a value.
+     */
+    public static function willSerialize(User $actor, User $user): void
+    {
+        $actorId = (int) $actor->id;
+
+        // A new actor invalidates anything queued for the previous one. In
+        // practice one request has one actor, but this keeps the queue honest
+        // if that ever stops being true.
+        if (self::$pendingActorId !== $actorId) {
+            self::$pendingUserIds = [];
+            self::$pendingActorId = $actorId;
+        }
+
+        self::$pendingUserIds[(int) $user->id] = true;
+    }
+
+    /**
+     * Load follow data for every user registered by willSerialize() that is not
+     * already cached, in one query per data set.
+     *
+     * Runs at most once per batch: the queue is cleared before the queries are
+     * issued, so the getters that resolve after the first one find their values
+     * already cached.
+     */
+    public static function resolvePending(): void
+    {
+        if (self::$pendingActorId === null || empty(self::$pendingUserIds)) {
+            return;
+        }
+
+        $actorId = self::$pendingActorId;
+        $userIds = array_keys(self::$pendingUserIds);
+
+        self::$pendingUserIds = [];
+        self::$pendingActorId = null;
+
+        // Only load what an earlier seed or a previous batch has not supplied.
+        $needsState = array_values(array_filter(
+            $userIds,
+            fn (int $id) => !array_key_exists($actorId.':'.$id, self::$followStateCache)
+        ));
+
+        $needsCounts = array_values(array_filter(
+            $userIds,
+            fn (int $id) => !isset(self::$followerCountCache[$id]) || !isset(self::$followingCountCache[$id])
+        ));
+
+        if (!empty($needsState)) {
+            self::seedActorFollowStates($actorId, $needsState);
+        }
+
+        if (!empty($needsCounts)) {
+            self::seedCountsFor($needsCounts);
+        }
+    }
+
+    /**
+     * Load follower and following counts for many users in two grouped queries
+     * rather than one COUNT per user.
+     *
+     * @param int[] $userIds
+     */
+    public static function seedCountsFor(array $userIds): void
+    {
+        if (empty($userIds)) {
+            return;
+        }
+
+        $followers = self::query()
+            ->selectRaw('followed_user_id, count(*) as aggregate')
+            ->whereIn('followed_user_id', $userIds)
+            ->groupBy('followed_user_id')
+            ->pluck('aggregate', 'followed_user_id');
+
+        $following = self::query()
+            ->selectRaw('user_id, count(*) as aggregate')
+            ->whereIn('user_id', $userIds)
+            ->groupBy('user_id')
+            ->pluck('aggregate', 'user_id');
+
+        // Users with no rows are absent from the grouped results, so default
+        // every requested ID to zero before applying what was found.
+        foreach ($userIds as $userId) {
+            self::$followerCountCache[$userId] = (int) ($followers[$userId] ?? 0);
+            self::$followingCountCache[$userId] = (int) ($following[$userId] ?? 0);
+        }
+    }
+
+    /**
+     * Discard all memoised state.
+     *
+     * Under php-fpm or the CLI the process ends with the request, so these
+     * caches never outlive it. A persistent runtime (Swoole, FrankenPHP worker
+     * mode, Octane) reuses the process, where a cache that is never cleared
+     * would serve data from an earlier request — including follow state that
+     * has since changed. Such a runtime should call this between requests.
+     */
+    public static function flushCache(): void
+    {
+        self::$followStateCache = [];
+        self::$followerCountCache = [];
+        self::$followingCountCache = [];
+        self::$pendingUserIds = [];
+        self::$pendingActorId = null;
+    }
+
+    /**
      * Get the follow subscription state for the given actor→user pair.
      * Returns the cached value if already loaded; otherwise queries the DB
      * and caches the result for the remainder of the request.
@@ -107,6 +234,12 @@ class FollowState extends AbstractModel
     public static function for(User $actor, User $user): ?string
     {
         $key = $actor->id.':'.$user->id;
+
+        if (!array_key_exists($key, self::$followStateCache)) {
+            // Load this user together with every other user queued for the same
+            // document, rather than one query for this one alone.
+            self::resolvePending();
+        }
 
         if (!array_key_exists($key, self::$followStateCache)) {
             $sub = self::where('user_id', $actor->id)->where('followed_user_id', $user->id)->first();
@@ -123,6 +256,10 @@ class FollowState extends AbstractModel
     public static function getFollowingCount(User $user): int
     {
         if (!isset(self::$followingCountCache[(int) $user->id])) {
+            self::resolvePending();
+        }
+
+        if (!isset(self::$followingCountCache[(int) $user->id])) {
             self::$followingCountCache[(int) $user->id] = self::where('user_id', $user->id)->count();
         }
 
@@ -135,6 +272,10 @@ class FollowState extends AbstractModel
      */
     public static function getFollowerCount(User $user): int
     {
+        if (!isset(self::$followerCountCache[(int) $user->id])) {
+            self::resolvePending();
+        }
+
         if (!isset(self::$followerCountCache[(int) $user->id])) {
             self::$followerCountCache[(int) $user->id] = self::where('followed_user_id', $user->id)->count();
         }

--- a/src/Middleware/FlushFollowStateCache.php
+++ b/src/Middleware/FlushFollowStateCache.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of ianm/follow-users
+ *
+ *  Copyright (c) Ian Morland.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace IanM\FollowUsers\Middleware;
+
+use IanM\FollowUsers\FollowState;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Discards FollowState's memoised data at the start of every request.
+ *
+ * The caches exist to collapse per-user queries within a single serialized
+ * document, so their useful life is exactly one request. Under php-fpm or the
+ * CLI that happens for free — the process ends with the request. Under a
+ * persistent runtime (Swoole, FrankenPHP worker mode, Octane) the process is
+ * reused, and without this the second request served by a worker would read
+ * follow state and counts captured during the first, returning data that may
+ * since have changed.
+ *
+ * Flushing on the way in rather than on the way out means a request always
+ * starts clean, even if an earlier one aborted before it could tidy up.
+ */
+class FlushFollowStateCache implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        FollowState::flushCache();
+
+        return $handler->handle($request);
+    }
+}

--- a/tests/integration/api/FollowStateCacheIsolationTest.php
+++ b/tests/integration/api/FollowStateCacheIsolationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of ianm/follow-users
+ *
+ *  Copyright (c) Ian Morland.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace IanM\FollowUsers\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use IanM\FollowUsers\FollowState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * FollowState memoises follow state and counts in static properties. Under
+ * php-fpm or the CLI each request is a fresh process, so those caches are
+ * effectively request-scoped and never outlive the request that filled them.
+ *
+ * Under a persistent runtime — Swoole, FrankenPHP worker mode, Octane — the
+ * process is reused, and a cache that is never cleared would serve one user's
+ * follow state to the next request. That is a correctness bug, not merely a
+ * stale-data one: the `followed` attribute is actor-specific.
+ *
+ * These tests issue two requests in a single process (PHPUnit isolates by test
+ * method, not by request) to assert the cache does not bleed between them.
+ */
+#[RunTestsInSeparateProcesses]
+class FollowStateCacheIsolationTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('ianm-follow-users');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'user3', 'email' => 'user3@machine.local', 'is_email_confirmed' => true],
+                ['id' => 4, 'username' => 'user4', 'email' => 'user4@machine.local', 'is_email_confirmed' => true],
+            ],
+            'user_followers' => [
+                // User 2 follows user 4. User 3 follows nobody.
+                ['id' => 1, 'user_id' => 2, 'followed_user_id' => 4, 'subscription' => 'follow', 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00'],
+            ],
+        ]);
+    }
+
+    protected function followedAttributeFor(int $actorId, int $userId): ?string
+    {
+        $response = $this->send(
+            $this->request('GET', "/api/users/{$userId}", ['authenticatedAs' => $actorId])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        return $json['data']['attributes']['followed'] ?? null;
+    }
+
+    /**
+     * The follow-state cache is keyed actor:user, so two different actors never
+     * collide. The exposure is staleness within one key: once actor 3's "not
+     * following" answer is cached, a later request in the same process keeps
+     * returning it even after actor 3 has started following.
+     */
+    #[Test]
+    public function follow_state_is_not_stale_across_requests(): void
+    {
+        $this->assertNull($this->followedAttributeFor(3, 4));
+
+        $response = $this->send(
+            $this->request('PATCH', '/api/users/4', [
+                'authenticatedAs' => 3,
+                'json'            => ['data' => ['attributes' => ['followUsers' => 'follow']]],
+            ])
+        );
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertEquals(
+            'follow',
+            $this->followedAttributeFor(3, 4),
+            'Follow state was served from a cache filled before the follow was created.'
+        );
+    }
+
+    /**
+     * Counts are not actor-specific, but a cache that outlives the request
+     * still serves figures that predate any change made since.
+     */
+    #[Test]
+    public function follower_counts_are_not_stale_across_requests(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/4', ['authenticatedAs' => 2])
+        );
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $this->assertEquals(1, $json['data']['attributes']['followerCount']);
+
+        // User 3 follows user 4, so the count must now be 2.
+        $response = $this->send(
+            $this->request('PATCH', '/api/users/4', [
+                'authenticatedAs' => 3,
+                'json'            => ['data' => ['attributes' => ['followUsers' => 'follow']]],
+            ])
+        );
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->send(
+            $this->request('GET', '/api/users/4', ['authenticatedAs' => 2])
+        );
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $this->assertEquals(
+            2,
+            $json['data']['attributes']['followerCount'],
+            'Follower count was served from a cache filled by an earlier request.'
+        );
+    }
+
+    /**
+     * The cache must be explicitly clearable, so a persistent runtime can reset
+     * it between requests regardless of how the state was seeded.
+     */
+    #[Test]
+    public function cache_can_be_flushed(): void
+    {
+        $this->app();
+
+        FollowState::seedCountCache(99, 7, 8);
+        FollowState::flushCache();
+
+        $user = User::query()->find(4);
+
+        $this->assertEquals(1, FollowState::getFollowerCount($user));
+    }
+}

--- a/tests/integration/api/IncludedUsersQueryCountTest.php
+++ b/tests/integration/api/IncludedUsersQueryCountTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/*
+ * This file is part of ianm/follow-users
+ *
+ *  Copyright (c) Ian Morland.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace IanM\FollowUsers\Tests\integration\api;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards against N+1 queries when User resources are serialized as *included*
+ * resources from endpoints other than UserResource::Index.
+ *
+ * The batch-loading in extend.php is attached to UserResource's Index endpoint,
+ * so it only primes the FollowState caches for /api/users. Every other endpoint
+ * that includes users — /api/discussions (firstUser, lastPostedUser), /api/posts
+ * (post authors) — serializes them with an empty cache, and each of the three
+ * FollowState field getters then falls through to its own per-user query.
+ *
+ * See https://github.com/imorland/follow-users/issues/56
+ */
+#[RunTestsInSeparateProcesses]
+class IncludedUsersQueryCountTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension('ianm-follow-users');
+    }
+
+    /**
+     * Seed $count discussions, each with a distinct author who the actor
+     * follows, so that any per-user query shape repeats once per discussion
+     * rather than being masked by a shared author.
+     */
+    protected function seedDiscussions(int $count): void
+    {
+        $users = [$this->normalUser()];
+        $discussions = [];
+        $posts = [];
+        $followers = [];
+
+        for ($i = 3; $i < 3 + $count; $i++) {
+            $users[] = [
+                'id'                 => $i,
+                'username'           => "user{$i}",
+                'email'              => "user{$i}@machine.local",
+                'is_email_confirmed' => true,
+            ];
+
+            $discussions[] = [
+                'id'                  => $i,
+                'title'               => "Discussion {$i}",
+                'user_id'             => $i,
+                'last_posted_user_id' => $i,
+                'first_post_id'       => $i,
+                'last_post_id'        => $i,
+                'comment_count'       => 1,
+                'is_private'          => 0,
+                'created_at'          => '2024-01-01 00:00:00',
+                'last_posted_at'      => '2024-01-01 00:00:00',
+            ];
+
+            $posts[] = [
+                'id'            => $i,
+                'discussion_id' => $i,
+                'user_id'       => $i,
+                'type'          => 'comment',
+                'content'       => "<t><p>Post {$i}</p></t>",
+                'number'        => 1,
+                'created_at'    => '2024-01-01 00:00:00',
+                'is_private'    => 0,
+            ];
+
+            $followers[] = [
+                'id'               => $i - 2,
+                'user_id'          => 2,
+                'followed_user_id' => $i,
+                'subscription'     => 'follow',
+                'created_at'       => '2024-01-01 00:00:00',
+                'updated_at'       => '2024-01-01 00:00:00',
+            ];
+        }
+
+        $this->prepareDatabase([
+            User::class       => $users,
+            Discussion::class => $discussions,
+            Post::class       => $posts,
+            'user_followers'  => $followers,
+        ]);
+    }
+
+    protected function countFollowStateQueries(int $authenticatedAs = 2): int
+    {
+        $database = $this->database();
+        $database->flushQueryLog();
+        $database->enableQueryLog();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => $authenticatedAs])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $log = $database->getQueryLog();
+        $database->flushQueryLog();
+
+        return count(array_filter(
+            $log,
+            fn ($query) => str_contains($query['query'], 'user_followers')
+        ));
+    }
+
+    /**
+     * The N+1 itself: RepeatedQueryDetector fails this test if any query shape
+     * repeats once per record.
+     */
+    #[Test]
+    public function listing_discussions_does_not_run_per_user_follow_queries(): void
+    {
+        $this->seedDiscussions(10);
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Proves the cost is O(1) rather than merely "under the detector's
+     * threshold": doubling the number of serialized users must not change the
+     * number of user_followers queries.
+     */
+    #[Test]
+    public function follow_state_query_count_does_not_grow_with_user_count(): void
+    {
+        $this->seedDiscussions(20);
+
+        $this->assertLessThanOrEqual(3, $this->countFollowStateQueries());
+    }
+
+    /**
+     * The included users must still serialize with correct follow data — a
+     * batch loader that returns nothing would satisfy the query-count
+     * assertions above while breaking the feature.
+     */
+    #[Test]
+    public function included_users_still_carry_correct_follow_attributes(): void
+    {
+        $this->seedDiscussions(3);
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $users = array_filter(
+            $json['included'] ?? [],
+            fn ($resource) => $resource['type'] === 'users'
+        );
+
+        $this->assertNotEmpty($users, 'Expected users to be included in the discussion listing.');
+
+        $byId = [];
+        foreach ($users as $user) {
+            $byId[(int) $user['id']] = $user['attributes'];
+        }
+
+        // The actor (user 2) follows users 3, 4 and 5.
+        foreach ([3, 4, 5] as $id) {
+            $this->assertArrayHasKey($id, $byId, "Expected user {$id} to be included.");
+            $this->assertEquals('follow', $byId[$id]['followed'] ?? null, "User {$id} should be followed by the actor.");
+            $this->assertEquals(1, $byId[$id]['followerCount'] ?? null, "User {$id} should have one follower.");
+            $this->assertEquals(0, $byId[$id]['followingCount'] ?? null, "User {$id} should follow nobody.");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #56

## The gap

The batch-loading added in #54 is attached to `UserResource`'s `Index` endpoint, so it only primes the `FollowState` caches for `/api/users`. `Endpoint::beforeSerialization` is bound to a single (resource, endpoint) pair, and `Extend\ApiResource` exposes no resource-wide "whenever this type is serialized" hook — so every other endpoint that includes users serialized them with a cold cache, and each of the three field getters fell through to its own per-user query.

That covers `/api/discussions` (`firstUser`, `lastPostedUser`), `/api/posts` (post authors), `/api/notifications`, and any third-party resource that includes users — i.e. most production traffic.

## The fix

The field getters now return a **closure** instead of a value. The serializer treats a returned `Closure` as deferred work (`Serializer::whenResolved` queues it; `resolveDeferred()` drains the queue at the top of `serialize()`), so it is only invoked once every model in the document has been walked.

That gives a point where the full set of users being serialized is known:

1. During the walk, each user registers itself via `FollowState::willSerialize()` — no queries.
2. The first closure to resolve finds a cold cache and loads follow state and counts for **all** registered users in three grouped queries.
3. Every subsequent closure is served from the warm cache.

This fixes every endpoint at once, including third-party ones, with no per-endpoint wiring. The existing `beforeSerialization` seeding stays as a fast path.

## Also: per-request cache flushing

`FollowState`'s caches are `private static` and were never cleared. Under php-fpm or the CLI the process ends with the request so they are effectively request-scoped, but under a persistent runtime (Swoole, FrankenPHP worker mode, Octane) the process is reused and the second request served by a worker would read follow state captured during the first. A middleware now flushes them at the start of each request.

## Measured

On a local forum with 9 distinct users serialized per `/api/discussions` page, counted via the MariaDB general log:

| | `user_followers` queries |
|---|---|
| before | **27** (3 shapes × 9 users) |
| after | **3** (grouped `IN (…)`) |

Constant as the user count grows. Response attributes verified unchanged — followed users still report `followed: "follow"` with correct counts.

## Tests

`flarum/testing` is pinned to `2.x-dev` for its `RepeatedQueryDetector`, which fails any request running one query per record. The new tests rely on it, so the pin ships with this PR; happy to move it back to a tagged constraint once one is released with the detector included.

- `IncludedUsersQueryCountTest` — the N+1 itself, an O(1) assertion across fixture sizes, and a correctness check that included users still carry the right follow attributes (a batch loader returning nothing would otherwise satisfy the query-count assertions).
- `FollowStateCacheIsolationTest` — staleness across requests in one process, for both follow state and counts, plus `flushCache()`.

All 34 integration tests pass; PHPStan clean.

## Note for maintainers

While instrumenting this I found `canBeFollowed` → `UserPolicy::follow()` → `$user->hasPermission()` issues one `group_permission` query per serialized user with *identical* bindings. Core has a `PermissionCache` intended to absorb exactly this, but it does not appear to be hitting — reproducible in isolation with two users. Since the bindings are identical it does not scale with data and is not an N+1, so I've left it alone; it looks like a core issue rather than one for this extension.